### PR TITLE
Rework trigger event based actions logic, to consider workflow_dispatch event

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,9 @@
 name: Bogus CI/CD Pipeline
 
+# There's is specific logic connected to the trigger events by exclusion: 
+# (github.event_name != 'pull_request')
+# When adding new events, make sure they conform to the logic
+# or if needed, make appropriate changes to keep the logic consistent
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
@@ -26,7 +30,7 @@ jobs:
         shell: powershell
         run: dotnet tool restore
 
-      - if: github.event_name == 'push'
+      - if: github.event_name != 'pull_request'
         name: Activate TestSpace tool
         id: testspace_tool
         uses: testspace-com/setup-testspace@v1
@@ -34,6 +38,7 @@ jobs:
           domain: ${{ github.repository_owner }}
           token: ${{ secrets.TESTSPACE_TOKEN }}
 
+      # (github.event_name == 'push') is used for steps specifically involved in the Release Sequence
       - if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         name: Bump release version and create release tag
         id: tag_generator
@@ -42,7 +47,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: false
 
-      - if: github.event_name == 'push'
+      - if: github.event_name != 'pull_request'
         name: Cache SonarCloud packages
         id: cache_sonar_packages
         uses: actions/cache@v2
@@ -51,7 +56,7 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
-      - if: github.event_name == 'push'
+      - if: github.event_name != 'pull_request'
         name: Cache SonarCloud scanner
         id: cache_sonar_scanner
         uses: actions/cache@v2
@@ -60,7 +65,7 @@ jobs:
           key: ${{ runner.os }}-sonar-scanner
           restore-keys: ${{ runner.os }}-sonar-scanner
 
-      - if: github.event_name == 'push' && steps.cache_sonar_scanner.outputs.cache-hit != 'true'
+      - if: github.event_name != 'pull_request' && steps.cache_sonar_scanner.outputs.cache-hit != 'true'
         name: Install SonarCloud scanner
         id: install_sonar_scanner
         shell: powershell
@@ -68,7 +73,7 @@ jobs:
           New-Item -Path .\.sonar\scanner -ItemType Directory
           dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
 
-      - if: github.event_name == 'push'
+      - if: github.event_name != 'pull_request'
         name: Lowercase string generator
         id: lowercase_string_gen
         shell: powershell
@@ -76,7 +81,7 @@ jobs:
           $LOWERCASE_OWNER = "${{ github.repository_owner }}".ToLower()
           echo "::set-output name=owner_name::$LOWERCASE_OWNER"
 
-      - if: github.event_name == 'push'
+      - if: github.event_name != 'pull_request'
         name: Initialize SonarCloud scanner
         id: init_sonar_scanner
         env:
@@ -105,7 +110,7 @@ jobs:
         shell: powershell
         run: dotnet fake run Source\Builder\build.fsx target test
 
-      - if: github.event_name == 'push' && always()
+      - if: github.event_name != 'pull_request' && always()
         name: Push result to Testspace server
         id: push_to_testspace
         shell: powershell
@@ -120,7 +125,7 @@ jobs:
           name: TestResults
           path: __test/
 
-      - if: github.event_name == 'push'
+      - if: github.event_name != 'pull_request'
         name: Send SonarCloud results
         id: send_sonar_results
         env:


### PR DESCRIPTION
I thought it would be appropriate for TestSpace and SonarCloud to execute on manually run workflow, therefor I switched the inclusive **github.event_name == 'push'**, with the exclusive **github.event_name != 'pull_request'**

I also add comments to focus attention for future changes, that the logic exists, so to be considered.